### PR TITLE
Add Pydantic model for INGInious submissions

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -2,6 +2,18 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## 1.1.0 (Aug 3rd, 2021)
+
+### Added
+
+- Shared exception handling functionality for subclasses of `INGIniousPage`.
+
+- Exception handler for `ValidationError` exceptions. Currently logs the exception and displays Internal Server Error in the browser.
+
+### Changed
+
+- Submissions are now validated with Pydantic. This makes it easier to reason with the code, as there is now a distinction between a raw submission returned by the INGInious `SubmissionManager` and a submission that has been parsed by the plugin and been assigned a `CodingStyleGrades` object.
+
 ## 1.0.2 (Aug 1st, 2021)
 
 ### Added

--- a/inginious_coding_style/__init__.py
+++ b/inginious_coding_style/__init__.py
@@ -29,7 +29,7 @@ from .utils import (
     get_submission_timestamp,
 )
 
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 
 PLUGIN_PATH = Path(__file__).parent.absolute()
 TEMPLATES_PATH = PLUGIN_PATH / "templates"

--- a/inginious_coding_style/_types.py
+++ b/inginious_coding_style/_types.py
@@ -1,9 +1,6 @@
 from typing import Any, Dict, Union, OrderedDict
 
 
-# An INGInious submission
-Submission = OrderedDict[str, Any]
-
 # Grades from a single category
 GradingCategoryIn = Dict[str, Union[str, int]]
 

--- a/inginious_coding_style/_types.py
+++ b/inginious_coding_style/_types.py
@@ -1,6 +1,5 @@
-from logging import Logger
-from typing import Any, Dict, Union, OrderedDict, Protocol
-from inginious.frontend.user_manager import UserManager
+from typing import Any, Dict, Union, OrderedDict
+
 
 # An INGInious submission
 Submission = OrderedDict[str, Any]
@@ -10,18 +9,3 @@ GradingCategoryIn = Dict[str, Union[str, int]]
 
 # Mapping of coding style grades
 GradesIn = Dict[str, GradingCategoryIn]
-
-
-class INGIniousPageProto(Protocol):
-    """Base class for INGInious page protocol types.
-    Only stipulates that a logger must be present for now."""
-
-    _logger: Logger
-
-
-class HasUserManager(INGIniousPageProto):
-    """Protocol type that stipulates the object must have access to the user manager."""
-
-    @property
-    def user_manager(self) -> UserManager:
-        ...

--- a/inginious_coding_style/exceptions.py
+++ b/inginious_coding_style/exceptions.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-from inginious.frontend.pages.utils import INGIniousAuthPage
+from inginious.frontend.pages.utils import INGIniousPage
 from pydantic import ValidationError
 from werkzeug.exceptions import InternalServerError
 
@@ -11,6 +11,6 @@ def handle_validation_error(exc: ValidationError) -> Tuple[str, int]:
     raise InternalServerError("Validation error")
 
 
-def init_exception_handlers(obj: INGIniousAuthPage) -> None:
+def init_exception_handlers(obj: INGIniousPage) -> None:
     # This function can be expanded with additional exception handlers
     obj.app.register_error_handler(ValidationError, handle_validation_error)

--- a/inginious_coding_style/exceptions.py
+++ b/inginious_coding_style/exceptions.py
@@ -1,0 +1,16 @@
+from typing import Tuple
+from inginious.frontend.pages.utils import INGIniousAuthPage
+from pydantic import ValidationError
+from werkzeug.exceptions import InternalServerError
+
+from .logger import get_logger
+
+
+def handle_validation_error(exc: ValidationError) -> Tuple[str, int]:
+    get_logger().error("A Pydantic validation error occured", exc_info=exc)
+    raise InternalServerError("Validation error")
+
+
+def init_exception_handlers(obj: INGIniousAuthPage) -> None:
+    # This function can be expanded with additional exception handlers
+    obj.app.register_error_handler(ValidationError, handle_validation_error)

--- a/inginious_coding_style/grades.py
+++ b/inginious_coding_style/grades.py
@@ -11,11 +11,6 @@ from pydantic import BaseModel, Field, validator
 from ._types import GradesIn
 
 
-class Grade(BaseModel):
-    grade: int = Field(default=100, ge=0, le=100)
-    feedback: str = Field(default="", max_length=5000)  # prevent unbounded text input
-
-
 class GradingCategory(BaseModel):
     """Represents a grading category."""
 

--- a/inginious_coding_style/grades.py
+++ b/inginious_coding_style/grades.py
@@ -112,7 +112,7 @@ class CodingStyleGrades(BaseModel):
             return round(avg, ndigits)
         return avg
 
-    def dict(self) -> Dict[str, GradingCategory]:  # type: ignore
+    def dict(self, *args, **kwargs) -> Dict[str, GradingCategory]:  # type: ignore
         """Returns a dict version of its own `__root__` attribute."""
         return super().dict()["__root__"]
 
@@ -126,6 +126,16 @@ def get_grades(
     # of CodingStyleGrades objects elsewhere in the plugin, if this is the
     # canonical way to create CodingStyleGrades objects.
     return CodingStyleGrades.parse_obj(grades)
+
+
+def add_config_categories(
+    grades: CodingStyleGrades, config: PluginConfig
+) -> CodingStyleGrades:
+    """Makes sure all enabled categories are added to a `CodingStyleGrades` object."""
+    for category_id, category in config.enabled.items():
+        if category_id not in grades:
+            grades.add_category(category)
+    return grades
 
 
 DEFAULT_CATEGORIES = {

--- a/inginious_coding_style/submission.py
+++ b/inginious_coding_style/submission.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from typing import Any, List, Optional, OrderedDict, Union
+
+from bson import ObjectId
+from pydantic import BaseModel, Field, validator, ValidationError
+
+from ._types import GradesIn
+from .grades import CodingStyleGrades, get_grades
+from .logger import get_logger
+
+
+class Custom(BaseModel):
+    coding_style_grades: CodingStyleGrades = Field(default_factory=CodingStyleGrades)
+
+    class Config:
+        # We don't care about other custom entries but we can't discard them
+        # because it might contain data from other plugins.
+        extra = "allow"
+
+    @validator("coding_style_grades", pre=True)
+    def get_style_grades(
+        cls, grades: Union[CodingStyleGrades, GradesIn]
+    ) -> Optional[CodingStyleGrades]:
+        if isinstance(grades, CodingStyleGrades):
+            return grades
+        try:
+            return get_grades(grades)
+        except ValidationError:
+            if grades:
+                # FIXME: Find out if this log is actually helpful
+                get_logger().error(f"Failed to validate grades: {grades}")
+            return None
+
+
+class Submission(BaseModel):
+    """Represents an INGInious submission."""
+
+    _id: ObjectId
+    courseid: str
+    taskid: str
+    submitted_on: datetime = Field(default_factory=datetime.now)
+    custom: Custom
+    username: List[str]
+    grade: float
+
+    class Config:
+        arbitrary_types_allowed = True # support ObjectId
+        extra = "allow"  # we don't validate the other dict keys
+
+    @validator("custom", pre=True)
+    def check_custom_key(cls, custom: Any) -> Union[dict, Custom]:
+        """Makes sure that the value for `custom` is either an instance
+        of `Custom` or a dict.
+
+        If the value is not a dict, it is inserted into a new dict under the key `"original"`
+        """
+        if isinstance(custom, Custom):
+            return custom
+        if not isinstance(custom, dict):
+            # Put original contents into a dict under key "original"
+            custom = {"original": custom}
+        return custom
+
+    def is_group_submission(self) -> bool:
+        return len(self.username) > 1
+
+
+def get_submission(submission: OrderedDict[str, Any]) -> Submission:
+    """Validates a submission returned by
+    `INGIniousAuthPage.submission_manager.get_submission()`.
+
+    Returns `Submission`
+    """
+    try:
+        sub = Submission(**submission)
+    except ValidationError:
+        get_logger().exception(f"Failed to validate submission {submission['_id']}")
+        raise
+    return sub

--- a/inginious_coding_style/submission.py
+++ b/inginious_coding_style/submission.py
@@ -10,6 +10,8 @@ from .logger import get_logger
 
 
 class Custom(BaseModel):
+    """Represents the contents of an INGInious submission's `"custom"` key."""
+
     coding_style_grades: CodingStyleGrades = Field(default_factory=CodingStyleGrades)
 
     class Config:
@@ -44,7 +46,7 @@ class Submission(BaseModel):
     grade: float
 
     class Config:
-        arbitrary_types_allowed = True # support ObjectId
+        arbitrary_types_allowed = True  # support ObjectId
         extra = "allow"  # we don't validate the other dict keys
 
     @validator("custom", pre=True)

--- a/inginious_coding_style/utils.py
+++ b/inginious_coding_style/utils.py
@@ -1,15 +1,16 @@
 from typing import List, Optional, TYPE_CHECKING
 
 from inginious.frontend.tasks import Task
+from inginious.frontend.pages.utils import INGIniousPage
 
-from ._types import Submission, HasUserManager
+from ._types import Submission
 
 if TYPE_CHECKING:
     from datetime import datetime
 
 
 def get_submission_authors_realname(
-    obj: HasUserManager, submission: Submission
+    obj: INGIniousPage, submission: Submission
 ) -> List[str]:
     """Retrieves a list of the real names of a submission's authors."""
     DEFAULT = "Unknown user"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "inginious-coding-style"
-version = "1.0.2"
+version = "1.1.0"
 description = ""
 authors = ["Peder Hovdan Andresen <pedeha@stud.ntnu.no>"]
 readme = "README.md"


### PR DESCRIPTION
## Abstract

This pull request adds Pydantic models for INGInious submissions (and the `"custom"` key). 

## Motivation

In the current version of the plugin it is difficult to reason with `Submission` objects, as you have to manually verify that its structure is correct:

- `submission["custom"]` is a dict,
- `submission["custom"]` has a dict in its `"coding_style"` key that contains coding style grades. 

Furthermore, even if the structure is correct, you still cannot be sure whether the contents of `submission["custom"]["coding_style"]` is an instance of `CodingStyleGrades` or a dict (after having called `.dict()` on the grades).

## Solution

This pull request solves those problems by defining the following Pydantic models:

```py
class Submission(BaseModel):
    """Represents an INGInious submission."""

    _id: ObjectId
    courseid: str
    taskid: str
    submitted_on: datetime = Field(default_factory=datetime.now)
    custom: Custom
    username: List[str]
    grade: float
   # ...
   
class Custom(BaseModel):
    """Represents the contents of an INGInious submission's `"custom"` key."""

    coding_style_grades: CodingStyleGrades = Field(default_factory=CodingStyleGrades)
```
__NOTE: Validators, config and other methods are omitted from the code excerpt above.__

With this, any time a function or method receives a `Submission` object, we can be sure it has a predictable structure. Checking if a submission has coding styles grades is as simple as:

```py
if submission.custom.coding_style_grades:
    # ...
```

## Problems

Pydantic is very opinionated, and should the structure of INGInious submissions change in a future version of INGInious, `Submission` will have to be updated to match the new changes. This is seen as a worthwhile tradeoff, as updating the model is easy with the help of Pydantic.

## Conclusion

These changes simplify development and makes it easier to write code that behaves predictably.

This pull request does not aim to change the user experience of the plugin, but only serves to make development easier and safer. 