### PR TITLE
Patch: Add detection and repair of unwritable configuration file

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Detection and repair of config that cannot be written to by inginious-webapp.
-    - Now shows an alert and button that can be pressed to attempt to make the configuration file writeable.
+    - Now shows an alert and button that can be pressed to attempt to make the configuration file writable.
 
 ## [1.5.0] 2021-12-05
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] 2021-12-08
+
+### Added
+
+- Detection and repair of config that cannot be written to by inginious-webapp.
+    - Now shows an alert and button that can be pressed to attempt to make the configuration file writeable.
+
 ## [1.5.0] 2021-12-05
 
 ### Added

--- a/inginious_coding_style/__init__.py
+++ b/inginious_coding_style/__init__.py
@@ -10,8 +10,9 @@ from inginious.frontend.template_helper import TemplateHelper
 
 from ._types import INGIniousSubmission
 from .config import PluginConfig, get_config
-from .pages import (CodingStyleGradingPage, NewCategoryEndpoint,
-                    PluginSettingsPage, StudentSubmissionCodingStylePage,
+from .pages import (CodingStyleGradingPage, FixConfigPermissionsEndpoint,
+                    NewCategoryEndpoint, PluginSettingsPage,
+                    StudentSubmissionCodingStylePage,
                     SubmissionStatusDiagnoser)
 from .utils import get_best_submission, has_coding_style_grades
 
@@ -238,6 +239,15 @@ def init(
         "/admin/<courseid>/settings/codingstyle/category",
         NewCategoryEndpoint.as_view(
             "new_category_endpoint",
+            config,
+            TEMPLATES_PATH,
+        ),
+    )
+
+    plugin_manager.add_page(
+        "/admin/<courseid>/settings/codingstyle/fixconfig",
+        FixConfigPermissionsEndpoint.as_view(
+            "fix_config_permissions_endpoint",
             config,
             TEMPLATES_PATH,
         ),

--- a/inginious_coding_style/__init__.py
+++ b/inginious_coding_style/__init__.py
@@ -16,7 +16,7 @@ from .pages import (CodingStyleGradingPage, FixConfigPermissionsEndpoint,
                     SubmissionStatusDiagnoser)
 from .utils import get_best_submission, has_coding_style_grades
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 PLUGIN_PATH = Path(__file__).parent.absolute()
 TEMPLATES_PATH = PLUGIN_PATH / "templates"

--- a/inginious_coding_style/fs.py
+++ b/inginious_coding_style/fs.py
@@ -70,7 +70,7 @@ def update_config_file(plugin_config: PluginConfig, config_path: Path) -> None:
     write_json_or_yaml(p, config)
 
 
-def is_writeable(fp: Union[str, Path, os.PathLike]) -> bool:
+def is_writable(fp: Union[str, Path, os.PathLike]) -> bool:
     return os.access(str(fp), os.W_OK)
 
 

--- a/inginious_coding_style/fs.py
+++ b/inginious_coding_style/fs.py
@@ -1,8 +1,10 @@
 """Module for filesystem functions."""
 
+import os
 import shutil
+import stat
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from inginious.common.base import load_json_or_yaml, write_json_or_yaml
 
@@ -66,3 +68,19 @@ def update_config_file(plugin_config: PluginConfig, config_path: Path) -> None:
     # Create backup of config before overwriting
     shutil.copy(p, f"{p}.bak")
     write_json_or_yaml(p, config)
+
+
+def is_writeable(fp: Union[str, Path, os.PathLike]) -> bool:
+    return os.access(str(fp), os.W_OK)
+
+
+def chmod(fp: Union[str, Path, os.PathLike], mode: int) -> None:
+    """Changes access permissions for a given file."""
+    p = Path(fp)
+    p.chmod(mode)
+
+
+def chmod_x(fp: Union[str, Path, os.PathLike]) -> None:
+    """Equivalent to running `chmod +x <fp>`."""
+    p = Path(fp)
+    p.chmod(p.stat().st_mode | stat.S_IWRITE)

--- a/inginious_coding_style/pages/__init__.py
+++ b/inginious_coding_style/pages/__init__.py
@@ -1,4 +1,5 @@
 from .grade_student import StudentSubmissionCodingStylePage
 from .grade_tutor import CodingStyleGradingPage
-from .plugin_settings import (NewCategoryEndpoint, PluginSettingsPage,
+from .plugin_settings import (FixConfigPermissionsEndpoint,
+                              NewCategoryEndpoint, PluginSettingsPage,
                               SubmissionStatusDiagnoser)

--- a/inginious_coding_style/pages/plugin_settings.py
+++ b/inginious_coding_style/pages/plugin_settings.py
@@ -20,7 +20,7 @@ from werkzeug.exceptions import BadRequest
 
 from .._types import INGIniousUserTask
 from ..config import PluginConfig, SubmissionQuerySettings, TaskListBars
-from ..fs import chmod_x, get_config_path, is_writeable, update_config_file
+from ..fs import chmod_x, get_config_path, is_writable, update_config_file
 from ..grades import GradingCategory
 from ..mixins import AdminPageMixin, SubmissionMixin
 from .base import BasePluginPage
@@ -189,10 +189,10 @@ class PluginSettingsPage(INGIniousAdminPage, BasePluginPage, SubmissionMixin):
         course, _ = self.get_course_and_check_rights(courseid)
 
         config_path = get_config_path()
-        if config_path is not None and is_writeable(config_path):
-            config_writeable = True
+        if config_path is not None and is_writable(config_path):
+            config_writable = True
         else:
-            config_writeable = False
+            config_writable = False
 
         return self.template_helper.render(
             "plugin_settings.html",
@@ -201,7 +201,7 @@ class PluginSettingsPage(INGIniousAdminPage, BasePluginPage, SubmissionMixin):
             user_manager=self.user_manager,
             config=self.config,
             config_path=config_path,
-            config_writeable=config_writeable,
+            config_writable=config_writable,
         )
 
     def POST_AUTH(self, courseid: str) -> str:

--- a/inginious_coding_style/templates/alert.html
+++ b/inginious_coding_style/templates/alert.html
@@ -1,0 +1,53 @@
+{# params:
+
+    # Message displayed in alert
+    message: str = "Success"
+
+    # Hyperscript to execute on alert
+    hyperscript: str = "on load wait 5s then transition opacity to 0 then remove me"
+
+    # Determine alert class based on success status
+    success: bool = False
+
+    # Alert div ID
+    id: Optional[str] = None
+
+    # Optionally pass in an exception
+    exception: Optional[Exception] = None
+
+    # overrides automatic class determined by `param: success`
+    class: Optional[str] = None
+#}
+
+
+<div
+    {% if not class %}
+        {% if success -%}
+            class="alert alert-success update-success"
+        {% else -%}
+            class="alert alert-danger"
+        {% endif -%}
+    {% else -%}
+        class="{{ class }}"
+    {% endif %}
+
+
+    {% if hyperscript -%}
+        {# a specified hyperscript arg always takes precedence #}
+        _="{{ hyperscript }}"
+    {% elif success %}
+        {# we default to a display then fade animation on success #}
+        _="{{ hyperscript | default('on load wait 5s then transition opacity to 0 then remove me', true)}}"
+    {% endif -%}
+
+    role="alert"
+
+    {% if id -%}
+        id="{{ id }}"
+    {%- endif -%}
+>
+{%- if success -%}
+    {{ message | default("Success", true) }}
+{%- else -%}
+    {{ message | default("Failure", true) }}
+{%- endif -%}{% if exception %} Reason: {e} {% endif %}</div>

--- a/inginious_coding_style/templates/plugin_settings.html
+++ b/inginious_coding_style/templates/plugin_settings.html
@@ -43,7 +43,28 @@
     </div>
 </div>
 
-<form id="codingstyle_settings_form" action="{{get_homepath()}}/admin/{{course.get_id()}}/settings/codingstyle" method="post">
+{% if config_path and not config_writeable %}
+<div id="not_writeable_alert">
+    <div class="alert alert-danger" role="alert">
+        The configuration file is not writable! Click the button to attempt to fix the problem.
+    </div>
+    <button
+        type="button"
+        class="btn btn-primary"
+        hx-confirm="This action will attempt to make the file writeable by user running inginious-webapp. Are you sure you want to proceed?"
+        hx-post="{{get_homepath()}}/admin/{{course.get_id()}}/settings/codingstyle/fixconfig"
+        hx-vals='{"config_path": "{{config_path.absolute()}}"}'
+        hx-target="#not_writeable_alert"
+
+    >Repair</button>
+</div>
+{% endif %}
+
+<form
+    id="codingstyle_settings_form"
+    action="{{get_homepath()}}/admin/{{course.get_id()}}/settings/codingstyle"
+    method="post"
+>
     <!-- Insert HTMX response here -->
     <div id="save-result">
     </div>
@@ -230,11 +251,11 @@
         <div class="col-sm-2"></div>
         <div class="col-sm-8">
             <button
-                _="on click go to the top of the body smoothly"
                 class="btn btn-primary btn-block"
                 type="submit"
                 hx-post="{{get_homepath()}}/admin/{{course.get_id()}}/settings/codingstyle"
                 hx-target="#save-result"
+                _="on click go to the top of the body smoothly"
             >
                 <i class="fa fa-download"></i> {{ _("Save changes") }}
             </button>

--- a/inginious_coding_style/templates/plugin_settings.html
+++ b/inginious_coding_style/templates/plugin_settings.html
@@ -43,18 +43,18 @@
     </div>
 </div>
 
-{% if config_path and not config_writeable %}
-<div id="not_writeable_alert">
+{% if config_path and not config_writable %}
+<div id="not_writable_alert">
     <div class="alert alert-danger" role="alert">
         The configuration file is not writable! Click the button to attempt to fix the problem.
     </div>
     <button
         type="button"
         class="btn btn-primary"
-        hx-confirm="This action will attempt to make the file writeable by user running inginious-webapp. Are you sure you want to proceed?"
+        hx-confirm="This action will attempt to make the file writable by user running inginious-webapp. Are you sure you want to proceed?"
         hx-post="{{get_homepath()}}/admin/{{course.get_id()}}/settings/codingstyle/fixconfig"
         hx-vals='{"config_path": "{{config_path.absolute()}}"}'
-        hx-target="#not_writeable_alert"
+        hx-target="#not_writable_alert"
 
     >Repair</button>
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "inginious-coding-style"
-version = "1.5.0"
+version = "1.5.1"
 description = ""
 authors = ["Peder Hovdan Andresen <pedeha@stud.ntnu.no>"]
 readme = "README.md"


### PR DESCRIPTION
This pull requests adds the ability to detect if the configuration file used by `inginious-webapp` is unwritable by the user running the process, when accessing the plugin settings page.

If the configuration file is detected as unwritable, a prompt to attempt repairs is shown. The "repair" consists of simply attempting to do `chmod +x <config_file` (albeit using `pathlib` and `stat`, not through a subprocess).

Bootstrap alerts are also moved to their own `alerts.html` template.