### PR TITLE
Add missing exception message when config permissions cannot be fixed.

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] 2021-12-10
+
+### Fixed
+
+- Config repair alert now displays exception message if config cannot be repaired.
+
 ## [1.5.1] 2021-12-08
 
 ### Added

--- a/inginious_coding_style/__init__.py
+++ b/inginious_coding_style/__init__.py
@@ -16,7 +16,7 @@ from .pages import (CodingStyleGradingPage, FixConfigPermissionsEndpoint,
                     SubmissionStatusDiagnoser)
 from .utils import get_best_submission, has_coding_style_grades
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 
 PLUGIN_PATH = Path(__file__).parent.absolute()
 TEMPLATES_PATH = PLUGIN_PATH / "templates"

--- a/inginious_coding_style/pages/plugin_settings.py
+++ b/inginious_coding_style/pages/plugin_settings.py
@@ -362,6 +362,7 @@ class FixConfigPermissionsEndpoint(INGIniousAdminPage, BasePluginPage):
                     f"Failed to change permissions of {config_path}."
                     f"You need to manually ensure the user running inginious-webapp has write permissions for {config_path}."
                 ),
+                exception=e,
             )
         else:
             return self.template_helper.render(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "inginious-coding-style"
-version = "1.5.1"
-description = ""
+version = "1.5.2"
+description = "INGInious plugin for grading of coding style."
 authors = ["Peder Hovdan Andresen <pedeha@stud.ntnu.no>"]
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Title. I just forgot to pass the exception to the alert in 1.5.1.

Also adds previously missing PyPi module description.